### PR TITLE
🩹fix: notification 쿼리 수정 - 컬럼명 변경 반영

### DIFF
--- a/src/main/resources/org/cardGGaduekMainService/notification/mapper/NotificationMapper.xml
+++ b/src/main/resources/org/cardGGaduekMainService/notification/mapper/NotificationMapper.xml
@@ -20,8 +20,8 @@
             n.message,
             n.image_url,
             n.link_url,
-            n.type_code_id,
-            n.status_code_id,
+            n.type_code,
+            n.status_code,
             n.created_at
         FROM notification n
                  JOIN member m ON n.member_id = m.id


### PR DESCRIPTION
## #️⃣연관된 이슈
> #20

## 📝작업 내용
> API 작업 전에 기존 Notification 기능을 테스트하던 중 오류를 발견했습니다.  
> `notification` 테이블에는 `type_code`, `status_code` 컬럼으로 되어 있었지만,  
> 코드 상에서는 `type_code_id`, `status_code_id`로 잘못 작성되어 있어 이를 수정했습니다.  

> 해당 오류로 인해 `SQLSyntaxErrorException: Unknown column 'n.type_code_id'` 에러가 발생했으며,  
> 쿼리 및 VO에서 컬럼명을 일치시켜 문제를 해결했습니다.

### 스크린샷 (선택)
> ❌ 쿼리 수정 사항으로 UI 변화 없음

## 💬리뷰 요구사항(선택)
> 쿼리 및 VO의 컬럼명이 DB 스키마와 일치하는지 확인 부탁드립니다.